### PR TITLE
Sitewide password authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,148 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is an Angular 18 monorepo for the Kick-In Media tool, a photo management application. The architecture consists of:
+
+- **Library (`media-tool`)**: Reusable components, services, and utilities in `src/`
+- **Applications**: Multiple branded instances in `projects/` (kick-in, batavierenrace, jwg) that consume the library
+
+Each application is a different deployment of the same tool with customized branding, API endpoints, and Auth0 configuration.
+
+## Development Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Start development server (runs kick-in app on port 3000)
+npm start
+
+# Build library
+npm run build
+
+# Run tests
+npm test
+
+# Generate backend API types from OpenAPI spec
+npm run api-spec
+```
+
+### Working with Specific Applications
+
+```bash
+# Serve a specific app
+ng serve <app-name>  # kick-in, batavierenrace, or jwg
+
+# Build a specific app
+ng build <app-name>
+
+# Test a specific app
+ng test <app-name>
+```
+
+## Architecture
+
+### Library + Multi-App Structure
+
+- `src/` contains the library code exported via `src/public-api.ts`
+- Applications bootstrap using `bootstrapMediaApp(config)` from the library
+- Each app in `projects/` has its own `main.ts` that provides app-specific configuration
+- Configuration includes: API hosts, Auth0 settings, branding (title, logo, website), contact info, and album grouping logic
+
+### Configuration System
+
+Apps configure the tool via `APP_CONFIG` injection token:
+
+- **apiHosts**: Maps frontend hosts to backend API hosts
+- **auth0**: Auth0 domain, clientId, and authorization parameters
+- **Corporate Identity**: title, logo, website
+- **contact**: name and email
+- **albums.groupIndex/groupName/groupSort**: Functions for grouping albums (e.g., by date)
+- **uploadIgnoreCriticalWarnings**: Whether to ignore critical EXIF warnings during upload
+
+See `src/config.ts` for the Config interface and `projects/kick-in/src/main.ts` for an example.
+
+### Services Architecture
+
+**BaseService Pattern** (`src/services/base.service.ts`):
+- Abstract base class for route-aware services
+- Provides `route$` observable tracking the innermost active route
+- `trackRouteParam(name)` helper for reactive route parameter tracking
+- `fetch()` method with caching, error handling, and default value support
+
+**API Services** (`src/services/api/`):
+- `event.service.ts`: Event CRUD operations
+- `album.service.ts`: Album CRUD operations
+- `photo.service.ts`: Photo CRUD, upload, download
+- `author.service.ts`: Photographer/author management
+
+All API services extend BaseService and use the reactive route tracking pattern.
+
+**Other Services**:
+- `account.service.ts`: User account and permissions
+- `s3.service.ts`: Direct S3 uploads
+- `download.service.ts`: Photo download handling
+- `share.service.ts`: Share functionality
+- `image-quality.service.ts`: Image quality configuration
+
+### Backend Integration
+
+- Backend types are auto-generated from OpenAPI spec: `npm run api-spec`
+- Types are stored in `src/util/back-end.d.ts`
+- API host routing is handled by `src/util/api.interceptor.ts` using the `apiHosts` config
+- The backend repository is at https://github.com/kickin-media/media-back-end/
+
+### Application Structure
+
+**Main Pages** (all in `src/app/`):
+- `home/`: Landing page (shows latest event if < 4 weeks old)
+- `event/`: Event overview and detail pages with album galleries
+- `album/`: Album photo gallery with lightbox
+- `upload/`: Photo upload interface with EXIF validation
+
+**Routes** (`src/app/app.routes.ts`):
+- `/` - Home page
+- `/event` - Event overview
+- `/event/:event_id/:event_slug` - Event detail
+- `/album/:album_id/:album_slug` - Album gallery
+- `/album/:album_id/:album_slug?lightbox=:photo_id` - Album with lightbox
+
+### Key Components
+
+**Lightbox** (`src/app/lightbox/`):
+- Full-screen photo viewer with navigation
+- Download options and photo management controls
+
+**Event Components** (`src/app/event/`):
+- Event cards, dialogs for CRUD operations
+- `event-overview.datasource.ts`: DataSource for paginated event lists
+
+**Album Components** (`src/app/album/`):
+- Album gallery grid with lazy loading
+- Album selection and management dialogs
+
+**Upload** (`src/app/upload/`):
+- Drag-and-drop photo upload with preview grid
+- EXIF validation and image resizing via `browser-image-resizer`
+- Critical warnings can be bypassed via `uploadIgnoreCriticalWarnings` config
+
+### Utilities
+
+- `src/util/types.d.ts`: Shared TypeScript interfaces
+- `src/util/validate-exif.ts`: EXIF metadata validation
+- `src/util/date.ts`: Date formatting utilities
+- `src/util/groupby.ts`: Array grouping helper
+
+### Authentication
+
+Uses Auth0 via `@auth0/auth0-angular` with scope-based permissions:
+- `events:manage`, `albums:manage`, `albums:read_hidden`
+- `photos:upload`, `photos:download_other`, `photos:delete_other`
+- `photos:manage_other`, `photos:read_view_count`
+
+## Testing
+
+Tests use Karma + Jasmine. Configuration is per-project in `tsconfig.spec.json` files. Component tests are skipped by default (see schematics config in `angular.json`).

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,6 +5,7 @@ import { routes } from './app.routes';
 import { Config } from "../config";
 import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { apiHttpInterceptor } from "../util/api.interceptor";
+import { basicAuthInterceptor } from "../util/basic-auth.interceptor";
 import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from "@angular/material/form-field";
 import { MAT_SNACK_BAR_DEFAULT_OPTIONS } from "@angular/material/snack-bar";
@@ -37,6 +38,7 @@ export const createAngularConfig: (config: Config<any>) => ApplicationConfig = (
 
     // HttpClient
     provideHttpClient(withInterceptors([
+      basicAuthInterceptor,
       apiHttpInterceptor(config.apiHosts),
       authHttpInterceptorFn
     ])),

--- a/src/components/basic-auth-dialog/basic-auth-dialog.component.html
+++ b/src/components/basic-auth-dialog/basic-auth-dialog.component.html
@@ -1,0 +1,27 @@
+<h2 mat-dialog-title>Authentication Required</h2>
+<mat-dialog-content>
+  <p>{{ data.hint }}</p>
+  <mat-form-field appearance="outline">
+    <mat-label>Password</mat-label>
+    <input
+      matInput
+      [type]="hidePassword ? 'password' : 'text'"
+      [formControl]="passwordField"
+      placeholder="Enter password"
+      autocomplete="current-password"
+      (keydown.enter)="submit()"
+    >
+    <button
+      mat-icon-button
+      matSuffix
+      type="button"
+      (click)="togglePasswordVisibility()"
+      [attr.aria-label]="'Toggle password visibility'"
+    >
+      <mat-icon>{{ hidePassword ? 'visibility' : 'visibility_off' }}</mat-icon>
+    </button>
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-flat-button color="primary" type="button" (click)="submit()">SUBMIT</button>
+</mat-dialog-actions>

--- a/src/components/basic-auth-dialog/basic-auth-dialog.component.scss
+++ b/src/components/basic-auth-dialog/basic-auth-dialog.component.scss
@@ -1,0 +1,11 @@
+:host > * {
+  max-width: min(calc(100vw - 4rem), 400px);
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+mat-dialog-content p {
+  margin-bottom: 1rem;
+}

--- a/src/components/basic-auth-dialog/basic-auth-dialog.component.ts
+++ b/src/components/basic-auth-dialog/basic-auth-dialog.component.ts
@@ -1,0 +1,46 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
+import { MatButtonModule } from "@angular/material/button";
+import { MatInputModule } from "@angular/material/input";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
+
+@Component({
+  selector: 'app-basic-auth-dialog',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './basic-auth-dialog.component.html',
+  styleUrl: './basic-auth-dialog.component.scss'
+})
+export class BasicAuthDialogComponent {
+  protected passwordField = new FormControl<string>('');
+  protected hidePassword = true;
+
+  constructor(
+    protected dialogRef: MatDialogRef<BasicAuthDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: BasicAuthDialogProps,
+  ) {}
+
+  submit(): void {
+    const password = this.passwordField.value;
+    if (password) {
+      this.dialogRef.close(password);
+    }
+  }
+
+  togglePasswordVisibility(): void {
+    this.hidePassword = !this.hidePassword;
+  }
+}
+
+export interface BasicAuthDialogProps {
+  hint: string;
+}

--- a/src/services/basic-auth.service.ts
+++ b/src/services/basic-auth.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+
+const STORAGE_KEY = 'sitewide_password';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BasicAuthService {
+  /**
+   * Store the password in localStorage, base64-encoded
+   */
+  setCredentials(password: string): void {
+    const encodedPassword = btoa(password);
+    localStorage.setItem(STORAGE_KEY, encodedPassword);
+  }
+
+  /**
+   * Get the X-Sitewide-Password header value (base64-encoded password)
+   */
+  getSitewidePasswordHeader(): string | null {
+    return localStorage.getItem(STORAGE_KEY);
+  }
+
+  /**
+   * Clear stored credentials
+   */
+  clearCredentials(): void {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}

--- a/src/util/basic-auth.interceptor.ts
+++ b/src/util/basic-auth.interceptor.ts
@@ -1,0 +1,83 @@
+import { HttpErrorResponse, HttpInterceptorFn, HttpRequest } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { catchError, Observable, shareReplay, switchMap, tap, throwError } from 'rxjs';
+import { BasicAuthService } from '../services/basic-auth.service';
+import { BasicAuthDialogComponent } from '../components/basic-auth-dialog/basic-auth-dialog.component';
+
+// Shared dialog observable to prevent multiple concurrent dialogs
+let pendingAuthDialog: Observable<string | null> | null = null;
+
+export const basicAuthInterceptor: HttpInterceptorFn = (req, next) => {
+  const basicAuthService = inject(BasicAuthService);
+  const dialog = inject(MatDialog);
+
+  // Add sitewide password header to API requests (relative URLs only)
+  const sitewidePassword = basicAuthService.getSitewidePasswordHeader();
+  if (sitewidePassword && !req.url.startsWith('http://') && !req.url.startsWith('https://')) {
+    req = req.clone({
+      setHeaders: { 'X-Sitewide-Password': sitewidePassword }
+    });
+  }
+
+  // Recursive helper to handle auth errors on both original and retry requests
+  const handleAuthError = (request: HttpRequest<any>, error: HttpErrorResponse): Observable<any> => {
+    // Check for sitewide authentication requirement
+    if (error.status === 401 && error.error?.error === 'authentication_required') {
+      // Ensure only one dialog is shown for concurrent 401s
+      if (!pendingAuthDialog) {
+        // Clear invalid credentials
+        basicAuthService.clearCredentials();
+
+        // Extract hint from response body
+        const hint = error.error?.hint || 'Please provide the password to access this application.';
+
+        // Open auth dialog
+        const dialogRef = dialog.open(BasicAuthDialogComponent, {
+          data: { hint },
+          disableClose: true,
+        });
+
+        // Share dialog result across concurrent requests
+        pendingAuthDialog = dialogRef.afterClosed().pipe(
+          tap(() => {
+            pendingAuthDialog = null;
+          }),
+          shareReplay(1)
+        );
+      }
+
+      // Wait for dialog result and retry request
+      return pendingAuthDialog.pipe(
+        switchMap((password: string | null) => {
+          if (password) {
+            // Store new credentials
+            basicAuthService.setCredentials(password);
+
+            // Retry request with new credentials
+            const retryReq = request.clone({
+              setHeaders: {
+                'X-Sitewide-Password': basicAuthService.getSitewidePasswordHeader()!
+              }
+            });
+
+            // Recursively handle errors on retry (e.g., wrong password)
+            return next(retryReq).pipe(
+              catchError((retryError: HttpErrorResponse) => handleAuthError(retryReq, retryError))
+            );
+          }
+
+          // User cancelled - propagate error
+          return throwError(() => error);
+        })
+      );
+    }
+
+    // Not a sitewide auth challenge - propagate error
+    return throwError(() => error);
+  };
+
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => handleAuthError(req, error))
+  );
+};

--- a/src/util/basic-auth.interceptor.ts
+++ b/src/util/basic-auth.interceptor.ts
@@ -20,61 +20,63 @@ export const basicAuthInterceptor: HttpInterceptorFn = (req, next) => {
     });
   }
 
+  // Shows the authentication dialog and returns an observable of the password
+  const showAuthDialog = (error: HttpErrorResponse): Observable<string | null> => {
+    // Clear invalid credentials
+    basicAuthService.clearCredentials();
+
+    // Extract hint from response body
+    const hint = error.error?.hint || 'Please provide the password to access this application.';
+
+    // Open auth dialog
+    const dialogRef = dialog.open(BasicAuthDialogComponent, {
+      data: { hint },
+      disableClose: true,
+    });
+
+    // Share dialog result across concurrent requests
+    return dialogRef.afterClosed().pipe(
+      tap(() => {
+        pendingAuthDialog = null;
+      }),
+      shareReplay(1)
+    );
+  };
+
   // Recursive helper to handle auth errors on both original and retry requests
   const handleAuthError = (request: HttpRequest<any>, error: HttpErrorResponse): Observable<any> => {
-    // Check for sitewide authentication requirement
-    if (error.status === 401 && error.error?.error === 'authentication_required') {
-      // Ensure only one dialog is shown for concurrent 401s
-      if (!pendingAuthDialog) {
-        // Clear invalid credentials
-        basicAuthService.clearCredentials();
-
-        // Extract hint from response body
-        const hint = error.error?.hint || 'Please provide the password to access this application.';
-
-        // Open auth dialog
-        const dialogRef = dialog.open(BasicAuthDialogComponent, {
-          data: { hint },
-          disableClose: true,
-        });
-
-        // Share dialog result across concurrent requests
-        pendingAuthDialog = dialogRef.afterClosed().pipe(
-          tap(() => {
-            pendingAuthDialog = null;
-          }),
-          shareReplay(1)
-        );
-      }
-
-      // Wait for dialog result and retry request
-      return pendingAuthDialog.pipe(
-        switchMap((password: string | null) => {
-          if (password) {
-            // Store new credentials
-            basicAuthService.setCredentials(password);
-
-            // Retry request with new credentials
-            const retryReq = request.clone({
-              setHeaders: {
-                'X-Sitewide-Password': basicAuthService.getSitewidePasswordHeader()!
-              }
-            });
-
-            // Recursively handle errors on retry (e.g., wrong password)
-            return next(retryReq).pipe(
-              catchError((retryError: HttpErrorResponse) => handleAuthError(retryReq, retryError))
-            );
-          }
-
-          // User cancelled - propagate error
-          return throwError(() => error);
-        })
-      );
+    // Not a sitewide auth challenge - propagate error
+    if (error.status !== 401 || error.error?.error !== 'authentication_required') {
+      return throwError(() => error);
     }
 
-    // Not a sitewide auth challenge - propagate error
-    return throwError(() => error);
+    // Ensure only one dialog is shown for concurrent 401s
+    if (!pendingAuthDialog) {
+      pendingAuthDialog = showAuthDialog(error);
+    }
+
+    // Wait for dialog result and retry request
+    return pendingAuthDialog.pipe(
+      switchMap((password: string | null) => {
+        // User cancelled - propagate error
+        if (!password) return throwError(() => error);
+
+        // Store new credentials
+        basicAuthService.setCredentials(password);
+
+        // Retry request with new credentials
+        const retryReq = request.clone({
+          setHeaders: {
+            'X-Sitewide-Password': basicAuthService.getSitewidePasswordHeader()!
+          }
+        });
+
+        // Recursively handle errors on retry (e.g., wrong password)
+        return next(retryReq).pipe(
+          catchError((retryError: HttpErrorResponse) => handleAuthError(retryReq, retryError))
+        );
+      })
+    );
   };
 
   return next(req).pipe(


### PR DESCRIPTION
This is a feature that is requested for one of the gallery instances. I was not happy with it, but I wanted to try out Claude anyway so I went ahead and tried to implement it.

The feature makes it so that the entire site can be put behind a password. This is not for user authentication, but for very low-effort keeping out of people that are not the intended audience (and hopefully also scrapers). I told the other stakeholders this is not safe, and just "best effort", but they wanted it anyway.

The implementation here does not care about the pass itself. That functionality is handled by the backend. When presented with an unauthenticated response, it will ask the user for a password, and send along that password with all subsequent requests.

This does not use the Basic Auth mechanism because that is incompatible with Bearer auth which we use for JWT with Auth0.

I tested this locally and it works. @jeffreybakker I'm very curious what you think of the code. I have not written a single line of it.