### PR TITLE
chore: fix permissions in issues GH actions

### DIFF
--- a/.github/workflows/add-issues-to-tracker.yaml
+++ b/.github/workflows/add-issues-to-tracker.yaml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   add-to-project:
     name: Add issue to the issue tracker.

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.14"
   NODE_VERSION: "20"


### PR DESCRIPTION
Potential fix for [https://github.com/kickin-media/media-front-end/security/code-scanning/1](https://github.com/kickin-media/media-front-end/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or the specific job) with least privilege.  
Best single fix here without changing behavior: add a workflow-level `permissions` block after `on:` and before `jobs:`.

For this workflow, a safe minimal baseline is:
- `contents: read` (standard read access)
- `issues: write` (the workflow is issue-triggered and may need issue/project mutation capabilities)

This keeps existing functionality while explicitly limiting token scope and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
